### PR TITLE
Replace gunicorn with waitress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Swapped out use of `gunicorn` for `waitress` to default to a WSGI server which will work in all environments (including Windows).
+* Added `waitress` as default WSGI server on Windows installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Swapped out use of `gunicorn` for `waitress` to default to a WSGI server written in pure Python, which will work in all environments (including Windows).
+* Swapped out use of `gunicorn` for `waitress` to default to a WSGI server which will work in all environments (including Windows).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Swapped out use of `environ.Env` for `environ.FileAwareEnv` to allow for loading environment variables from files in addition to standard environment variables.
+
+## [0.2.0] - 2023-10-17
+
+### Added
+
+* Swapped out use of `gunicorn` for `waitress` to default to a WSGI server written in pure Python, which will work in all environments (including Windows).

--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ By default, static files are loaded from apps and the `static` directory in your
 
 ## Running in production
 
+### Mac OS/Linux
+
 Start the webserver with `python manage.py gunicorn`.
 
 Set the `WEB_CONCURRENCY` environment variable to the number of gunicorn workers you want to run. Start with 2x the number of CPU cores.
+
+### Windows
+
+Start the webserver with `python manage.py waitress --port=8000`.
 
 ### Required environment variables
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When you install the package, it will install the following dependencies:
 
 * `whitenoise` - for serving static files
 * `django-environ` - for reading settings from environment variables
-* `django-webserver[waitress]` - for running the webserver via `manage.py`
+* `django-webserver[gunicorn]` - for running the webserver via `manage.py`
 * `django-alive` - for a health check endpoint at `/-/alive/`
 
 Running `django-production-apply` will append the `django-production` settings to your project's settings file and add the healthcheck endpoint to your project's `urlpatterns`. You can see the settings that are added in [settings.py](https://github.com/lincolnloop/django-production/blob/main/django_production/settings.py).
@@ -26,7 +26,9 @@ By default, static files are loaded from apps and the `static` directory in your
 
 ## Running in production
 
-Start the webserver with `python manage.py waitress --port=8000`.
+Start the webserver with `python manage.py gunicorn`.
+
+Set the `WEB_CONCURRENCY` environment variable to the number of gunicorn workers you want to run. Start with 2x the number of CPU cores.
 
 ### Required environment variables
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When you install the package, it will install the following dependencies:
 
 * `whitenoise` - for serving static files
 * `django-environ` - for reading settings from environment variables
-* `django-webserver[gunicorn]` - for running the webserver via `manage.py`
+* `django-webserver[waitress]` - for running the webserver via `manage.py`
 * `django-alive` - for a health check endpoint at `/-/alive/`
 
 Running `django-production-apply` will append the `django-production` settings to your project's settings file and add the healthcheck endpoint to your project's `urlpatterns`. You can see the settings that are added in [settings.py](https://github.com/lincolnloop/django-production/blob/main/django_production/settings.py).
@@ -26,9 +26,7 @@ By default, static files are loaded from apps and the `static` directory in your
 
 ## Running in production
 
-Start the webserver with `python manage.py gunicorn`.
-
-Set the `WEB_CONCURRENCY` environment variable to the number of gunicorn workers you want to run. Start with 2x the number of CPU cores.
+Start the webserver with `python manage.py waitress --port=8000`.
 
 ### Required environment variables
 

--- a/django_production/__init__.py
+++ b/django_production/__init__.py
@@ -1,3 +1,3 @@
 """django-production gets your project production ready"""
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.2.0.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version", "description"]
 dependencies = [
     "django-environ",
     "whitenoise",
-    "django-webserver[gunicorn]",
+    "django-webserver[waitress]",
     "django-alive",
 ]
 keywords = ["django", "production", "deployment"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version", "description"]
 dependencies = [
     "django-environ",
     "whitenoise",
-    "django-webserver[waitress]",
+    "django-webserver[gunicorn]",
     "django-alive",
 ]
 keywords = ["django", "production", "deployment"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dynamic = ["version", "description"]
 dependencies = [
     "django-environ",
     "whitenoise",
-    "django-webserver[gunicorn]",
+    "django-webserver[gunicorn]; platform_system != 'Windows'",
+    "django-webserver[waitress]; platform_system == 'Windows'",
     "django-alive",
 ]
 keywords = ["django", "production", "deployment"]

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -131,7 +131,7 @@ def test_staticfiles_prod(django_env_prod):
     do_patch()
     subprocess.check_call(["./manage.py", "collectstatic", "--noinput"])
     with start_server(
-        cmd=["./manage.py", "gunicorn"], env={"WEB_CONCURRENCY": "1", **os.environ}
+        cmd=["./manage.py", "waitress", "--port=8000"], env={**os.environ}
     ):
         http = urllib3.PoolManager()
         resp = http.request(

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -131,7 +131,7 @@ def test_staticfiles_prod(django_env_prod):
     do_patch()
     subprocess.check_call(["./manage.py", "collectstatic", "--noinput"])
     with start_server(
-        cmd=["./manage.py", "waitress", "--port=8000"], env={**os.environ}
+        cmd=["./manage.py", "gunicorn"], env={"WEB_CONCURRENCY": "1", **os.environ}
     ):
         http = urllib3.PoolManager()
         resp = http.request(


### PR DESCRIPTION
Hi there! 👋️

Just heard @ipmb give a lightning talk on this nifty tool at DjangoCon US. Something that immediately stuck out to me is that it uses gunicorn by default. That presents a problem for Windows users. Fortunately, django-webserver also supports waitress from the Pylons folks, which works on Windows. This PR replaces gunicorn with waitress to give Windows developers a better experience.

Thoughts?